### PR TITLE
environment portability

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Trusona
 Tags: trusona, no-passwords, no passwords, no password, passwordless login, mfa, 2fa, authentication, multi-factor-authentication, sso, single-sign-on, security, 2 step, 2 step authentication, 2-factor, 2FA, 2 factor authentication, access, access management, authentication, biometric, biometrics, decentralized, encryption, fencing, fingerprint, geofencing, identity, IAM, iPhone, log in, login, MFA, mobile, MFA, multi-factor, multifactor, multi factor authentication, out of band, OOB, password, passwords, phishing, phone, PIN, secure, security, security policies, SSL, strong authentication, token, tokens, two step, two factor, two-factor authentication, white label, wp-admin, wp-login, login, no more passwords, password, qr code, security, 1 google authenticator, 2 step authentication, 2-Factor, 2FA, authenticate, authy, authy two factor, Clef, device Id, duo, email verification, google, google authenticator, KBA, knowledge based authentication, login, login security, Mobile Authentication, multi factor authentication, multi-factor, Multifactor authentication, no password, one time passcode, otp, password, passwordless login, qr code, QR Code Authentication, scan QR Code, security, smartphone authentication, soft token, strong authentication, trusted device, two factor auth, two-factor, two-factor authentication, two-step verification, website security, woocommerce, wordfence, yubico
 Requires at least: 4.0
-Tested up to: 4.7.3
-Stable tag: 1.1.5
+Tested up to: 4.7.4
+Stable tag: 1.1.7
 License: MIT
 
 Secure your WP accounts with Trusona's FREE #NoPasswords plug-in. Add admins, prevent unauthorized logins and access your account with ease.
@@ -100,10 +100,16 @@ Visit our website at www.trusona.com
 
 == Upgrade Notice ==
 
+= 1.1.7 =
+* Implemented dynamic registration when environment relocation is detected.
+
 = 1.1.0 =
-Added new feature: Trusona ONLY Mode (available in settings)
+* Added new feature: Trusona ONLY Mode (available in settings)
 
 == Changelog ==
+
+= 1.1.7 =
+* Add portability between testing and production environments with dynamic registration when a change is detected.
 
 = 1.1.6 =
 * Add filters to modify locked down form variables


### PR DESCRIPTION
- Fixing this issue - https://wordpress.org/support/topic/redirect-uri-error/ - by,
   - Generating a hash that we compare to with a similarly generated hash each time we load the plugin.
   - If different, for instance, when an environment is moved from `testing` to `production`, registration is performed to get a refreshed `client id` and `client secret`